### PR TITLE
Clean up keyvalue methods

### DIFF
--- a/src/keyvalue.rs
+++ b/src/keyvalue.rs
@@ -17,7 +17,7 @@ use crate::gen_bb_uuid;
 /// * Any `KeyValue` -> `Value` via `into()`
 ///
 /// ```rust
-/// use arora_schema::keyvalue::{KeyValue, KeyValueField, KeyValueSet};
+/// use arora_schema::keyvalue::{KeyValue, KeyValueField, KeyValueItems};
 /// use arora_schema::value::Value;
 /// use arora_schema::gen_bb_uuid;
 ///
@@ -41,7 +41,7 @@ use crate::gen_bb_uuid;
 /// ]).into();
 ///
 /// // Nested structure via helper
-/// let stats_set = KeyValueSet::from(vec![
+/// let stats_set = KeyValueItems::from(vec![
 ///   KeyValueField::new("strength", Value::I32(50)),
 ///   KeyValueField::new("agility", Value::I32(75)),
 /// ]);


### PR DESCRIPTION
Cleaning up and simplifying the KeyValue API for creation and manipulation of these structures to facilitate its adoption as part of the `arora-types` package.

To re-summarize the concept of KeyValues:
- The main KeyValue structure has
  - a name
  - an id
  - a KeyValueSet

The KeyValueSet is just a helper that acts as a vec of KeyValueFields and allows for more uniform interfacing
  
 - the KeyValueField is a type that contains 
    - a name (key)
    - an id 
    - and a Value    


Mostly what I did in this PR was
- Remove methods/options that were no longer necessary
- Consolidate some abstraction e.g. created the KeyValueSet type which equates to a vector of KeyValueField to make interfaces cleaner.
- Remove confusing options such as "create from pairs"


A nice creation example can be found in the `test_keyvalue_nested_structure_without_ids`:

```rust
let player_kv = KeyValue::make_kv_from_fields(&[
      KeyValueField::new("health", Value::I32(100)),
      KeyValueField::new_nested_kv(
        "stats",
        &KeyValueSet::from(vec![
          KeyValueField::new("strength", Value::I32(50)),
          KeyValueField::new("agility", Value::I32(75)),
        ]),
      ),
      KeyValueField::new_nested_kv(
        "position",
        &KeyValueSet::from(vec![
          KeyValueField::new("x", Value::F32(10.0)),
          KeyValueField::new("y", Value::F32(20.0)),
        ]),
      ),
    ]);
```