### PR TITLE
Fix crates.io publish in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,22 +139,18 @@ jobs:
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Rust Crate (release only) — must run before wasm-pack which dirties Cargo.lock
+      # Rust Crate (release only)
       - name: Package crate
         if: steps.params.outputs.is_release == 'true'
         run: cargo package
 
-      - name: Publish to crates.io (Trusted Publisher / OIDC)
-        if: steps.params.outputs.is_release == 'true'
-        run: cargo publish
-
-      # WASM build for GitHub Release artifact
+      # WASM / NPM
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM for release
         run: |
-          wasm-pack build --release --scope=semio-ai
+          wasm-pack build --release --scope=semio-ai -- --locked
           wasm-pack pack
 
       - name: Tag and push
@@ -184,3 +180,7 @@ jobs:
               "${CRATE_FILE}" \
               "${NPM_TGZ}"
           fi
+
+      - name: Publish to crates.io (Trusted Publisher / OIDC)
+        if: steps.params.outputs.is_release == 'true'
+        run: cargo publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_and_test, check-version-bump]
     permissions:
-      id-token: write  # Required for OIDC (NPM trusted publish)
+      id-token: write  # Required for OIDC (crates.io trusted publish)
       contents: write
       packages: write
     steps:
@@ -139,12 +139,16 @@ jobs:
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Rust Crate (release only)
+      # Rust Crate (release only) — must run before wasm-pack which dirties Cargo.lock
       - name: Package crate
         if: steps.params.outputs.is_release == 'true'
         run: cargo package
 
-      # WASM / NPM
+      - name: Publish to crates.io (Trusted Publisher / OIDC)
+        if: steps.params.outputs.is_release == 'true'
+        run: cargo publish
+
+      # WASM build for GitHub Release artifact
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
@@ -180,9 +184,3 @@ jobs:
               "${CRATE_FILE}" \
               "${NPM_TGZ}"
           fi
-
-      - name: Publish to crates.io
-        if: steps.params.outputs.is_release == 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arora-types"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Shared type definitions for the Semio Arora framework"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Move `cargo package` and `cargo publish` before the wasm-pack build step, which dirties `Cargo.lock` and causes `cargo package` to fail with "uncommitted changes"
- Use crates.io Trusted Publisher (OIDC) instead of `CRATES_IO_TOKEN` secret — the repo is already configured as a trusted publisher
- Remove NPM publish steps (already done in previous commit — `package.json` is `private: true`)

## Context

Run [#83](https://github.com/semio-ai/arora-types/actions/runs/24461115742/job/71475752160) failed at the "Package crate" step because wasm-pack modified `Cargo.lock`.

## Test plan

- [ ] Merge and verify the publish job succeeds on main