### PR TITLE
Set CARGO_REGISTRY_TOKEN to oidc:github for Trusted Publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,4 +183,6 @@ jobs:
 
       - name: Publish to crates.io (Trusted Publisher / OIDC)
         if: steps.params.outputs.is_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: oidc:github
         run: cargo publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arora-types"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "derive_more",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arora-types"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "Shared type definitions for the Semio Arora framework"
 license = "MIT"


### PR DESCRIPTION
cargo publish needs the explicit token value "oidc:github" to trigger the OIDC token exchange with crates.io. id-token:write permission alone is not sufficient.